### PR TITLE
Create test form fxn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-scripts": "5.0.1",
         "redux": "^4.2.0",
         "redux-thunk": "^2.4.1",
+        "uuid": "^8.3.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
     "redux-thunk": "^2.4.1",
+    "uuid": "^8.3.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/CreateTest.jsx
+++ b/src/components/CreateTest.jsx
@@ -74,9 +74,7 @@ function CreateTest() {
       },
     };
 
-    console.log(testData);
     const data = await apiClient.createTest(testData);
-    console.log(data);
 
     resetValues();
   };

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -11,7 +11,7 @@ function Header() {
               src="https://img.icons8.com/ios/344/lol--v1.png"
               alt="NoName"
             />
-            <div className="ml-3 text-2xl font-semibold text-gray-900">NoName</div>
+            <div className="ml-3 text-2xl font-semibold text-gray-900">Seymour</div>
           </div>
           <div className="flex">
             <button className="text-sm font-medium text-sky-600 hover:text-sky-700">Docs</button>

--- a/src/components/shared/Button.jsx
+++ b/src/components/shared/Button.jsx
@@ -1,8 +1,8 @@
 import { React } from 'react';
 
-function Button({ message, save = false }) {
+function Button({ message, save = false, onClick }) {
   return (
-    <button type="button" className={`${save ? 'bg-green-600 hover:bg-green-600 text-white w-full' : ''} hover:bg-gray-300 px-4 py-1 text-sm font-semibold rounded border text-gray-900`}>
+    <button onClick={onClick} type="button" className={`${save ? 'bg-green-600 hover:bg-green-600 text-white w-full' : ''} hover:bg-gray-300 px-4 py-1 text-sm font-semibold rounded border text-gray-900`}>
       { message }
     </button>
   );

--- a/src/components/shared/TextSelect.jsx
+++ b/src/components/shared/TextSelect.jsx
@@ -3,6 +3,13 @@ import { React } from 'react';
 function Select({
   label, placeholder, name, id, options, onChange,
 }) {
+  const optionValue = (opt) => {
+    if (opt.value) {
+      return opt.value;
+    }
+    return opt.name;
+  };
+
   if (options) {
     return (
       <div>
@@ -17,7 +24,7 @@ function Select({
             placeholder={placeholder}
             onChange={onChange}
           >
-            { options.map((opt) => <option value={opt.value | opt.name}>{opt.displayName}</option>) }
+            { options.map((opt) => <option value={optionValue(opt)}>{opt.displayName}</option>) }
           </select>
         </div>
       </div>

--- a/src/components/shared/TextSelect.jsx
+++ b/src/components/shared/TextSelect.jsx
@@ -17,7 +17,7 @@ function Select({
             placeholder={placeholder}
             onChange={onChange}
           >
-            { options.map((option) => <option>{option.displayName}</option>)}
+            { options.map((option) => <option value={option.name}>{option.displayName}</option>)}
           </select>
         </div>
       </div>

--- a/src/components/shared/TextSelect.jsx
+++ b/src/components/shared/TextSelect.jsx
@@ -17,7 +17,7 @@ function Select({
             placeholder={placeholder}
             onChange={onChange}
           >
-            { options.map((option) => <option value={option.name}>{option.displayName}</option>)}
+            { options.map((opt) => <option value={opt.value | opt.name}>{opt.displayName}</option>) }
           </select>
         </div>
       </div>

--- a/src/components/test-new/AssertionRow.jsx
+++ b/src/components/test-new/AssertionRow.jsx
@@ -1,4 +1,5 @@
 import { React } from 'react';
+import { camelCaseToDisplayName } from '../../utils/helpers';
 
 function AssertionRow({
   source, property, comparison, target,
@@ -6,13 +7,13 @@ function AssertionRow({
   return (
     <tr>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        {source}
+        {camelCaseToDisplayName(source)}
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
         {property}
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        {comparison}
+        {camelCaseToDisplayName(comparison)}
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
         {target}

--- a/src/components/test-new/AssertionRow.jsx
+++ b/src/components/test-new/AssertionRow.jsx
@@ -1,13 +1,21 @@
 import { React } from 'react';
+import { useDispatch } from 'react-redux';
+import { deleteAssertion } from '../../features/newtest/newtest';
 import { camelCaseToDisplayName } from '../../utils/helpers';
 
 function AssertionRow({
-  source, property, comparison, target,
+  id, type, property, comparison, target,
 }) {
+  const dispatch = useDispatch();
+
+  const handleDeleteAssertion = () => {
+    dispatch(deleteAssertion(id));
+  };
+
   return (
     <tr>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        {camelCaseToDisplayName(source)}
+        {camelCaseToDisplayName(type)}
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
         {property}
@@ -19,13 +27,13 @@ function AssertionRow({
         {target}
       </td>
       <td>
-        <div className="pl-2">
+        <button type="button" className="pl-2" onClick={handleDeleteAssertion}>
           <img
             className="h-6 w-auto"
             src="https://img.icons8.com/external-others-iconmarket/344/external-delete-essential-others-iconmarket-3.png"
             alt="NoName"
           />
-        </div>
+        </button>
       </td>
     </tr>
   );

--- a/src/components/test-new/AssertionRows.jsx
+++ b/src/components/test-new/AssertionRows.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import AssertionRow from './AssertionRow';
+
+function AssertionRows({ assertions }) {
+  if (assertions) {
+    return (
+      <tbody className="divide-y divide-gray-200">
+        {assertions.map((assertion) => (
+          <AssertionRow
+            key={assertion.id}
+            source={assertion.source}
+            property={assertion.property}
+            comparison={assertion.comparison}
+            target={assertion.target}
+          />
+        ))}
+      </tbody>
+    );
+  }
+}
+
+export default AssertionRows;

--- a/src/components/test-new/AssertionRows.jsx
+++ b/src/components/test-new/AssertionRows.jsx
@@ -8,7 +8,8 @@ function AssertionRows({ assertions }) {
         {assertions.map((assertion) => (
           <AssertionRow
             key={assertion.id}
-            source={assertion.source}
+            id={assertion.id}
+            type={assertion.type}
             property={assertion.property}
             comparison={assertion.comparison}
             target={assertion.target}

--- a/src/components/test-new/AssertionsInput.jsx
+++ b/src/components/test-new/AssertionsInput.jsx
@@ -1,27 +1,9 @@
 import { React } from 'react';
 import { useSelector } from 'react-redux';
-import AssertionRow from './AssertionRow';
 import AssertionRows from './AssertionRows';
 import NewAssertionRow from './NewAssertionRow';
 
-// const configuredAssertions = [
-//   {
-//     id: 1, source: 'Status code', comparison: 'Equal to', target: '200',
-//   },
-//   {
-//     id: 2, source: 'Body', property: '$.title', comparison: 'Equal to', target: 'test board #1',
-//   },
-//   {
-//     id: 3, source: 'Headers', property: '$Content-Type', comparison: 'Equal to', target: 'application/json',
-//   },
-//   {
-//     id: 4, source: 'Response time', comparison: 'Less than', target: '400',
-//   },
-// ];
-
 function AssertionsInput() {
-  // const dispatch = useDispatch();
-
   const assertions = useSelector((state) => state.newtest.httpRequest.assertions);
 
   const keyValueToAssertion = (key, value) => ({

--- a/src/components/test-new/AssertionsInput.jsx
+++ b/src/components/test-new/AssertionsInput.jsx
@@ -1,23 +1,56 @@
 import { React } from 'react';
+import { useSelector } from 'react-redux';
 import AssertionRow from './AssertionRow';
+import AssertionRows from './AssertionRows';
 import NewAssertionRow from './NewAssertionRow';
 
-const configuredAssertions = [
-  {
-    id: 1, source: 'Status code', comparison: 'Equal to', target: '200',
-  },
-  {
-    id: 2, source: 'Body', property: '$.title', comparison: 'Equal to', target: 'test board #1',
-  },
-  {
-    id: 3, source: 'Headers', property: '$Content-Type', comparison: 'Equal to', target: 'application/json',
-  },
-  {
-    id: 4, source: 'Response time', comparison: 'Less than', target: '400',
-  },
-];
+// const configuredAssertions = [
+//   {
+//     id: 1, source: 'Status code', comparison: 'Equal to', target: '200',
+//   },
+//   {
+//     id: 2, source: 'Body', property: '$.title', comparison: 'Equal to', target: 'test board #1',
+//   },
+//   {
+//     id: 3, source: 'Headers', property: '$Content-Type', comparison: 'Equal to', target: 'application/json',
+//   },
+//   {
+//     id: 4, source: 'Response time', comparison: 'Less than', target: '400',
+//   },
+// ];
 
 function AssertionsInput() {
+  // const dispatch = useDispatch();
+
+  const assertions = useSelector((state) => state.newtest.httpRequest.assertions);
+
+  const keyValueToAssertion = (key, value) => ({
+    key: `${key}${value.comparison}${value.target}`,
+    source: key,
+    property: value.property,
+    comparison: value.comparison,
+    target: value.target,
+  });
+
+  const assertionsToArray = (assertions) => {
+    const parsed = [];
+    const keys = Object.keys(assertions);
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+      const value = assertions[key];
+      if (!Array.isArray(value)) {
+        parsed.push(keyValueToAssertion(key, value));
+      } else {
+        value.forEach((a) => {
+          parsed.push(keyValueToAssertion(key, a));
+        });
+      }
+    }
+    return parsed;
+  };
+
+  const assertionsArr = assertionsToArray(assertions);
+
   return (
     <div className="mt-8 flex flex-col">
       <h2>Assertions</h2>
@@ -39,17 +72,7 @@ function AssertionsInput() {
             <th scope="col" className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900" />
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-200">
-          {configuredAssertions.map((assertion) => (
-            <AssertionRow
-              key={assertion.id}
-              source={assertion.source}
-              property={assertion.property}
-              comparison={assertion.comparison}
-              target={assertion.target}
-            />
-          ))}
-        </tbody>
+        <AssertionRows assertions={assertionsArr} />
         <NewAssertionRow />
       </table>
     </div>

--- a/src/components/test-new/AssertionsInput.jsx
+++ b/src/components/test-new/AssertionsInput.jsx
@@ -6,34 +6,6 @@ import NewAssertionRow from './NewAssertionRow';
 function AssertionsInput() {
   const assertions = useSelector((state) => state.newtest.httpRequest.assertions);
 
-  const keyValueToAssertion = (key, value) => ({
-    key: `${key}${value.comparison}${value.target}`,
-    source: key,
-    property: value.property,
-    comparison: value.comparison,
-    target: value.target,
-  });
-
-  const assertionsToArray = (assertions) => {
-    const parsed = [];
-    const keys = Object.keys(assertions);
-    for (let i = 0; i < keys.length; i += 1) {
-      const key = keys[i];
-      const value = assertions[key];
-      if (!Array.isArray(value)) {
-        parsed.push(keyValueToAssertion(key, value));
-      } else {
-        value.forEach((a) => {
-          parsed.push(keyValueToAssertion(key, a));
-        });
-      }
-    }
-    console.log('parsed: ', parsed);
-    return parsed;
-  };
-
-  const assertionsArr = assertionsToArray(assertions);
-
   return (
     <div className="mt-8 flex flex-col">
       <h2>Assertions</h2>
@@ -55,7 +27,7 @@ function AssertionsInput() {
             <th scope="col" className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900" />
           </tr>
         </thead>
-        <AssertionRows assertions={assertionsArr} />
+        <AssertionRows assertions={assertions} />
         <NewAssertionRow />
       </table>
     </div>

--- a/src/components/test-new/AssertionsInput.jsx
+++ b/src/components/test-new/AssertionsInput.jsx
@@ -28,6 +28,7 @@ function AssertionsInput() {
         });
       }
     }
+    console.log('parsed: ', parsed);
     return parsed;
   };
 

--- a/src/components/test-new/CreateNewTest.jsx
+++ b/src/components/test-new/CreateNewTest.jsx
@@ -53,6 +53,10 @@ function CreateNewTest() {
     dispatch(addUrl(url));
   };
 
+  const handleSaveConfiguration = () => {
+    // get from redux store and send to DB?!
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-8 pb-20">
       <div className="flex justify-between">
@@ -84,7 +88,7 @@ function CreateNewTest() {
       <LocationsInput />
       <FrequencyInput />
       <div className="mt-5 flex">
-        <Button message="Save" save />
+        <Button onClick={handleSaveConfiguration} message="Save" save />
       </div>
     </div>
   );

--- a/src/components/test-new/CreateNewTest.jsx
+++ b/src/components/test-new/CreateNewTest.jsx
@@ -8,15 +8,13 @@ import { fetchSideloads } from '../../features/sideloads/sideloads';
 import FrequencyInput from './FrequencyInput';
 import Button from '../shared/Button';
 import { addMethod, addTitle, addUrl } from '../../features/newtest/newtest';
+import apiClient from '../../services/ApiClient';
 
 function CreateNewTest() {
   const dispatch = useDispatch();
 
   const httpMethods = useSelector((state) => state.sideloads.httpMethods);
-  const newTestConfiguration = useSelector((state) => {
-    console.log('newtest: ', state.newtest);
-    return state.newtest;
-  });
+  const newTestConfiguration = useSelector((state) => state.newtest);
 
   useEffect(() => {
     dispatch(fetchSideloads());
@@ -46,7 +44,9 @@ function CreateNewTest() {
   };
 
   const handleSaveConfiguration = () => {
-    console.log('currentState: ', newTestConfiguration);
+    // TODO: uncomment once test-crud and rest of the pipeline are migrated to new payload shape
+    // apiClient.createTest(newTestConfiguration);
+    console.log('newTestConfiguration: ', newTestConfiguration);
   };
 
   return (

--- a/src/components/test-new/CreateNewTest.jsx
+++ b/src/components/test-new/CreateNewTest.jsx
@@ -25,6 +25,10 @@ function CreateNewTest() {
   const dispatch = useDispatch();
 
   const httpMethods = useSelector((state) => state.sideloads.httpMethods);
+  const configuration = useSelector((state) => {
+    console.log('newtest: ', state.newtest);
+    return state.newtest;
+  });
 
   useEffect(() => {
     dispatch(fetchSideloads());
@@ -54,7 +58,8 @@ function CreateNewTest() {
   };
 
   const handleSaveConfiguration = () => {
-    // get from redux store and send to DB?!
+    const currentState = getState().newtest;
+    console.log('currentState: ', currentState);
   };
 
   return (

--- a/src/components/test-new/CreateNewTest.jsx
+++ b/src/components/test-new/CreateNewTest.jsx
@@ -2,9 +2,6 @@ import { React, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import TextSelect from '../shared/TextSelect';
 import TextInput from '../shared/TextInput';
-import Toggle from './Toggle';
-import TextBlockInput from './TextBlockInput';
-import KeyValueInput from './KeyValueInput';
 import AssertionsInput from './AssertionsInput';
 import LocationsInput from './LocationsInput';
 import { fetchSideloads } from '../../features/sideloads/sideloads';
@@ -12,20 +9,11 @@ import FrequencyInput from './FrequencyInput';
 import Button from '../shared/Button';
 import { addMethod, addTitle, addUrl } from '../../features/newtest/newtest';
 
-const configuredHeaders = [
-  { name: 'Content-Type', value: 'application/json' },
-  { name: 'Accept-Encoding', value: 'gzip, deflate' },
-];
-
-const configuredQueryParams = [
-  { name: 'age', value: '144d' },
-];
-
 function CreateNewTest() {
   const dispatch = useDispatch();
 
   const httpMethods = useSelector((state) => state.sideloads.httpMethods);
-  const configuration = useSelector((state) => {
+  const newTestConfiguration = useSelector((state) => {
     console.log('newtest: ', state.newtest);
     return state.newtest;
   });
@@ -58,8 +46,7 @@ function CreateNewTest() {
   };
 
   const handleSaveConfiguration = () => {
-    const currentState = getState().newtest;
-    console.log('currentState: ', currentState);
+    console.log('currentState: ', newTestConfiguration);
   };
 
   return (
@@ -68,10 +55,6 @@ function CreateNewTest() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Create a test</h1>
         </div>
-        {/* <div className="flex">
-          <Toggle />
-          <div className="pl-2">Activated</div>
-        </div> */}
       </div>
       <TextInput onChange={handleTitleChange} onBlur={handleSubmitNewTitle} label="Test name" placeholder="My new test" type="text" name="test_name" id="test_name" />
 
@@ -86,9 +69,6 @@ function CreateNewTest() {
         </div>
       </div>
 
-      {/* <TextBlockInput label="Body" placeholder="JSON goes here" name="test_name" id="test_name" /> */}
-      {/* <KeyValueInput label="Headers" buttonLabel="Add header" data={configuredHeaders} />
-      <KeyValueInput label="Query params" buttonLabel="Add query param" data={configuredQueryParams} /> */}
       <AssertionsInput />
       <LocationsInput />
       <FrequencyInput />

--- a/src/components/test-new/CreateNewTest.jsx
+++ b/src/components/test-new/CreateNewTest.jsx
@@ -59,10 +59,10 @@ function CreateNewTest() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Create a test</h1>
         </div>
-        <div className="flex">
+        {/* <div className="flex">
           <Toggle />
           <div className="pl-2">Activated</div>
-        </div>
+        </div> */}
       </div>
       <TextInput onChange={handleTitleChange} onBlur={handleSubmitNewTitle} label="Test name" placeholder="My new test" type="text" name="test_name" id="test_name" />
 
@@ -77,9 +77,9 @@ function CreateNewTest() {
         </div>
       </div>
 
-      <TextBlockInput label="Body" placeholder="JSON goes here" name="test_name" id="test_name" />
-      <KeyValueInput label="Headers" buttonLabel="Add header" data={configuredHeaders} />
-      <KeyValueInput label="Query params" buttonLabel="Add query param" data={configuredQueryParams} />
+      {/* <TextBlockInput label="Body" placeholder="JSON goes here" name="test_name" id="test_name" /> */}
+      {/* <KeyValueInput label="Headers" buttonLabel="Add header" data={configuredHeaders} />
+      <KeyValueInput label="Query params" buttonLabel="Add query param" data={configuredQueryParams} /> */}
       <AssertionsInput />
       <LocationsInput />
       <FrequencyInput />

--- a/src/components/test-new/FrequencyInput.jsx
+++ b/src/components/test-new/FrequencyInput.jsx
@@ -1,4 +1,6 @@
-import { React } from 'react';
+import { React, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { setMinutesBetweenRuns } from '../../features/newtest/newtest';
 import TextInput from '../shared/TextInput';
 import TextSelect from '../shared/TextSelect';
 
@@ -9,15 +11,47 @@ const unitsOfTime = [
 ];
 
 function FrequencyInput() {
+  const dispatch = useDispatch();
+
+  const [intervalValue, setIntervalValue] = useState(null);
+  const [intervalUnits, setIntervalUnits] = useState('minutes');
+
+  const minutes = (value, units) => {
+    switch (units) {
+      case 'minutes':
+        return value;
+      case 'hours':
+        return Number(value) * 60;
+      case 'days':
+        return Number(value) * 60 * 24;
+      default:
+        console.log('Unknown units of time');
+    }
+  };
+
+  const handleIntervalValueChange = (e) => {
+    setIntervalValue(e.target.value);
+    dispatch(setMinutesBetweenRuns(
+      String(minutes(intervalValue, intervalUnits)),
+    ));
+  };
+
+  const handleIntervalValueSelect = (e) => {
+    setIntervalUnits(e.target.value);
+    dispatch(setMinutesBetweenRuns(
+      String(minutes(intervalValue, intervalUnits)),
+    ));
+  };
+
   return (
     <div className="mt-8">
       <h2>Time between test runs?</h2>
       <div className="mt-4 flex">
         <div className="pr-3">
-          <TextInput label="Value" placeholder="#" type="text" name="frequency_value" id="frequency_value" />
+          <TextInput onChange={handleIntervalValueChange} label="Value" placeholder="#" type="text" name="frequency_value" id="frequency_value" />
         </div>
         <div>
-          <TextSelect label="Units" options={unitsOfTime} />
+          <TextSelect onChange={handleIntervalValueSelect} label="Units" options={unitsOfTime} />
         </div>
       </div>
     </div>

--- a/src/components/test-new/FrequencyInput.jsx
+++ b/src/components/test-new/FrequencyInput.jsx
@@ -1,9 +1,10 @@
-import { React, useState } from 'react';
+import { React } from 'react';
 import { useDispatch } from 'react-redux';
 import { setMinutesBetweenRuns } from '../../features/newtest/newtest';
 import TextSelect from '../shared/TextSelect';
 
 const frequencyOptions = [
+  { displayName: 'Select value', value: '5' },
   { displayName: '1 minute', value: '1' },
   { displayName: '5 minutes', value: '5' },
   { displayName: '15 minutes', value: '15' },

--- a/src/components/test-new/FrequencyInput.jsx
+++ b/src/components/test-new/FrequencyInput.jsx
@@ -1,57 +1,35 @@
 import { React, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { setMinutesBetweenRuns } from '../../features/newtest/newtest';
-import TextInput from '../shared/TextInput';
 import TextSelect from '../shared/TextSelect';
 
-const unitsOfTime = [
-  { displayName: 'minutes' },
-  { displayName: 'hours' },
-  { displayName: 'days' },
+const frequencyOptions = [
+  { displayName: '1 minute', value: '1' },
+  { displayName: '5 minutes', value: '5' },
+  { displayName: '15 minutes', value: '15' },
+  { displayName: '30 minutes', value: '30' },
+  { displayName: '1 hour', value: '60' },
+  { displayName: '3 hours', value: '180' },
+  { displayName: '6 hours', value: '360' },
+  { displayName: '12 hours', value: '720' },
+  { displayName: '1 day', value: '1440' },
+  { displayName: '2 days', value: '2880' },
+  { displayName: '1 week', value: '10080' },
 ];
 
 function FrequencyInput() {
   const dispatch = useDispatch();
 
-  const [intervalValue, setIntervalValue] = useState(null);
-  const [intervalUnits, setIntervalUnits] = useState('minutes');
-
-  const minutes = (value, units) => {
-    switch (units) {
-      case 'minutes':
-        return value;
-      case 'hours':
-        return Number(value) * 60;
-      case 'days':
-        return Number(value) * 60 * 24;
-      default:
-        console.log('Unknown units of time');
-    }
-  };
-
-  const handleIntervalValueChange = (e) => {
-    setIntervalValue(e.target.value);
-    dispatch(setMinutesBetweenRuns(
-      String(minutes(intervalValue, intervalUnits)),
-    ));
-  };
-
-  const handleIntervalValueSelect = (e) => {
-    setIntervalUnits(e.target.value);
-    dispatch(setMinutesBetweenRuns(
-      String(minutes(intervalValue, intervalUnits)),
-    ));
+  const handleIntervalUnitsSelect = async (e) => {
+    dispatch(setMinutesBetweenRuns(e.target.value));
   };
 
   return (
     <div className="mt-8">
       <h2>Time between test runs?</h2>
       <div className="mt-4 flex">
-        <div className="pr-3">
-          <TextInput onChange={handleIntervalValueChange} label="Value" placeholder="#" type="text" name="frequency_value" id="frequency_value" />
-        </div>
         <div>
-          <TextSelect onChange={handleIntervalValueSelect} label="Units" options={unitsOfTime} />
+          <TextSelect onChange={handleIntervalUnitsSelect} options={frequencyOptions} />
         </div>
       </div>
     </div>

--- a/src/components/test-new/NewAssertionRow.jsx
+++ b/src/components/test-new/NewAssertionRow.jsx
@@ -7,15 +7,19 @@ import { addAssertion } from '../../features/newtest/newtest';
 function NewAssertionRow() {
   const dispatch = useDispatch();
 
-  const assertionTypes = useSelector((state) => state.sideloads.assertionTypes);
+  const assertionTypes = useSelector((state) => {
+    console.log('assertionTypes: ', state.sideloads.assertionTypes);
+    return state.sideloads.assertionTypes;
+  });
   const comparisonTypes = useSelector((state) => state.sideloads.comparisonTypes);
 
-  const [type, setType] = useState('');
-  const [property, setProperty] = useState(null);
-  const [comparisonType, setComparisonType] = useState(null);
+  const [type, setType] = useState('responseTime');
+  const [property, setProperty] = useState('');
+  const [comparisonType, setComparisonType] = useState('equalTo');
   const [target, setTarget] = useState('');
 
   const handleNewType = (e) => {
+    console.log('new type:', e.target.value);
     setType(e.target.value);
   };
 

--- a/src/components/test-new/NewAssertionRow.jsx
+++ b/src/components/test-new/NewAssertionRow.jsx
@@ -38,6 +38,9 @@ function NewAssertionRow() {
       comparisonType,
       target,
     };
+    setProperty('');
+    setTarget('');
+
     dispatch(addAssertion(newAssertion));
   };
 
@@ -59,7 +62,7 @@ function NewAssertionRow() {
         <TextSelect onChange={handleNewComparisonType} options={comparisonTypes} />
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        <TextInput onChange={handleTargetChange} type="text" />
+        <TextInput onChange={handleTargetChange} value={target} type="text" />
       </td>
       <td>
         <button type="button" onClick={handleNewAssertionSubmit}>Add</button>

--- a/src/components/test-new/NewAssertionRow.jsx
+++ b/src/components/test-new/NewAssertionRow.jsx
@@ -1,5 +1,6 @@
 import { React, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { v4 as uuidv4 } from 'uuid';
 import TextSelect from '../shared/TextSelect';
 import TextInput from '../shared/TextInput';
 import { addAssertion } from '../../features/newtest/newtest';
@@ -19,7 +20,6 @@ function NewAssertionRow() {
   const [target, setTarget] = useState('');
 
   const handleNewType = (e) => {
-    console.log('new type:', e.target.value);
     setType(e.target.value);
   };
 
@@ -37,9 +37,10 @@ function NewAssertionRow() {
 
   const handleNewAssertionSubmit = () => {
     const newAssertion = {
-      name: type,
+      id: uuidv4(), // for assertion lookup and deletion
+      type,
       property,
-      comparisonType,
+      comparison: comparisonType,
       target,
     };
     setProperty('');

--- a/src/components/test-new/NewAssertionRow.jsx
+++ b/src/components/test-new/NewAssertionRow.jsx
@@ -41,13 +41,19 @@ function NewAssertionRow() {
     dispatch(addAssertion(newAssertion));
   };
 
+  const propertyInput = () => {
+    if (['body', 'headers'].includes(type)) {
+      return <TextInput onChange={handlePropertyChange} type="text" />;
+    }
+  };
+
   return (
     <tr>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
         <TextSelect onChange={handleNewType} options={assertionTypes} />
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        <TextInput onChange={handlePropertyChange} type="text" />
+        { propertyInput() }
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
         <TextSelect onChange={handleNewComparisonType} options={comparisonTypes} />

--- a/src/components/test-new/NewAssertionRow.jsx
+++ b/src/components/test-new/NewAssertionRow.jsx
@@ -1,28 +1,62 @@
-import { React } from 'react';
-import { useSelector } from 'react-redux';
+import { React, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import TextSelect from '../shared/TextSelect';
 import TextInput from '../shared/TextInput';
+import { addAssertion } from '../../features/newtest/newtest';
 
 function NewAssertionRow() {
+  const dispatch = useDispatch();
+
   const assertionTypes = useSelector((state) => state.sideloads.assertionTypes);
   const comparisonTypes = useSelector((state) => state.sideloads.comparisonTypes);
+
+  const [type, setType] = useState('');
+  const [property, setProperty] = useState(null);
+  const [comparisonType, setComparisonType] = useState(null);
+  const [target, setTarget] = useState('');
+
+  const handleNewType = (e) => {
+    setType(e.target.value);
+  };
+
+  const handlePropertyChange = (e) => {
+    setProperty(e.target.value);
+  };
+
+  const handleNewComparisonType = (e) => {
+    setComparisonType(e.target.value);
+  };
+
+  const handleTargetChange = (e) => {
+    setTarget(e.target.value);
+  };
+
+  const handleNewAssertionSubmit = () => {
+    const newAssertion = {
+      name: type,
+      property,
+      comparisonType,
+      target,
+    };
+    dispatch(addAssertion(newAssertion));
+  };
 
   return (
     <tr>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        <TextSelect options={assertionTypes} />
+        <TextSelect onChange={handleNewType} options={assertionTypes} />
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        <TextInput type="text" />
+        <TextInput onChange={handlePropertyChange} type="text" />
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        <TextSelect options={comparisonTypes} />
+        <TextSelect onChange={handleNewComparisonType} options={comparisonTypes} />
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-gray-500">
-        <TextInput type="text" />
+        <TextInput onChange={handleTargetChange} type="text" />
       </td>
       <td>
-        Add
+        <button type="button" onClick={handleNewAssertionSubmit}>Add</button>
       </td>
     </tr>
   );

--- a/src/components/test-new/NewAssertionRow.jsx
+++ b/src/components/test-new/NewAssertionRow.jsx
@@ -8,10 +8,7 @@ import { addAssertion } from '../../features/newtest/newtest';
 function NewAssertionRow() {
   const dispatch = useDispatch();
 
-  const assertionTypes = useSelector((state) => {
-    console.log('assertionTypes: ', state.sideloads.assertionTypes);
-    return state.sideloads.assertionTypes;
-  });
+  const assertionTypes = useSelector((state) => state.sideloads.assertionTypes);
   const comparisonTypes = useSelector((state) => state.sideloads.comparisonTypes);
 
   const [type, setType] = useState('responseTime');

--- a/src/components/test-new/RegionCard.jsx
+++ b/src/components/test-new/RegionCard.jsx
@@ -1,18 +1,39 @@
-import { React } from 'react';
+import { React, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { toggleLocation } from '../../features/newtest/newtest';
 
 function RegionCard({ region }) {
+  const dispatch = useDispatch();
+
+  const [selected, setSelected] = useState(false);
+
+  const toggleSelected = () => {
+    setSelected(!selected);
+  };
+
+  const handleRegionClick = () => {
+    dispatch(toggleLocation(region.awsName));
+    toggleSelected();
+  };
+
   return (
-    <div className="grid justify-items-center rounded border text-gray-900 hover:bg-gray-300">
-      <div className="flex items-center">
-        <div className="w-8 ml-2 pr-2">
-          <img src={region.flagUrl} alt={region.name} />
-        </div>
-        <div className="text-center">
-          <div className="text-gray-900">{region.displayName}</div>
-          <div className="text-sm">{region.awsName}</div>
+    <button
+      onClick={handleRegionClick}
+      type="button"
+      value={region.name}
+    >
+      <div className={`${selected ? 'bg-sky-200 hover:bg-sky-300' : 'bg-gray-100 hover:bg-gray-300'} grid justify-items-center rounded border text-gray-900`}>
+        <div className="flex items-center">
+          <div className="w-8 ml-2 pr-2">
+            <img src={region.flagUrl} alt={region.name} />
+          </div>
+          <div className="text-center">
+            <div className="text-gray-900">{region.displayName}</div>
+            <div className="text-sm">{region.awsName}</div>
+          </div>
         </div>
       </div>
-    </div>
+    </button>
   );
 }
 

--- a/src/features/newtest/newtest.js
+++ b/src/features/newtest/newtest.js
@@ -10,10 +10,7 @@ const initialState = {
     url: '',
     headers: {},
     body: {},
-    assertions: {
-      headers: [],
-      jsonBody: [],
-    },
+    assertions: [],
   },
 };
 
@@ -31,36 +28,10 @@ export const newtestSlice = createSlice({
       state.httpRequest.url = action.payload;
     },
     addAssertion: (state, action) => {
-      console.log('action.payload: ', action.payload);
-      switch (action.payload.name) {
-        case 'statusCode':
-        case 'responseTime':
-          state.httpRequest.assertions[action.payload.name] = {
-            comparison: action.payload.comparisonType,
-            target: action.payload.target,
-          };
-          break;
-        case 'body':
-          state.httpRequest.assertions.jsonBody.push(
-            {
-              comparison: action.payload.comparisonType,
-              property: action.payload.property,
-              target: action.payload.target,
-            },
-          );
-          break;
-        case 'headers':
-          state.httpRequest.assertions[action.payload.name].push(
-            {
-              comparison: action.payload.comparisonType,
-              property: action.payload.property,
-              target: action.payload.target,
-            },
-          );
-          break;
-        default:
-          console.log('Assertion type not found');
-      }
+      state.httpRequest.assertions.push(action.payload);
+    },
+    deleteAssertion: (state, action) => {
+      state.httpRequest.assertions = state.httpRequest.assertions.filter((a) => a.id !== action.payload);
     },
     toggleLocation: (state, action) => {
       const location = action.payload;
@@ -77,7 +48,7 @@ export const newtestSlice = createSlice({
 });
 
 export const {
-  addTitle, addMethod, toggleLocation, addUrl, addAssertion, setMinutesBetweenRuns,
+  addTitle, addMethod, toggleLocation, addUrl, addAssertion, deleteAssertion, setMinutesBetweenRuns,
 } = newtestSlice.actions;
 
 export default newtestSlice.reducer;

--- a/src/features/newtest/newtest.js
+++ b/src/features/newtest/newtest.js
@@ -62,14 +62,22 @@ export const newtestSlice = createSlice({
           console.log('Assertion type not found');
       }
     },
-    addLocation: (state, action) => {
-      state.locations.push(action.payload);
+    toggleLocation: (state, action) => {
+      const location = action.payload;
+      if (state.locations.includes(location)) {
+        state.locations.filter((l) => l !== location);
+      } else {
+        state.locations.push(location);
+      }
+    },
+    setMinutesBetweenRuns: (state, action) => {
+      state.minutesBetweenRuns = action.payload;
     },
   },
 });
 
 export const {
-  addTitle, addMethod, addLocation, addUrl, addAssertion,
+  addTitle, addMethod, toggleLocation, addUrl, addAssertion, setMinutesBetweenRuns,
 } = newtestSlice.actions;
 
 export default newtestSlice.reducer;

--- a/src/features/newtest/newtest.js
+++ b/src/features/newtest/newtest.js
@@ -30,6 +30,38 @@ export const newtestSlice = createSlice({
     addUrl: (state, action) => {
       state.httpRequest.url = action.payload;
     },
+    addAssertion: (state, action) => {
+      console.log('action.payload: ', action.payload);
+      switch (action.payload.name) {
+        case 'statusCode':
+        case 'responseTime':
+          state.httpRequest.assertions[action.payload.name] = {
+            comparison: action.payload.comparisonType,
+            target: action.payload.target,
+          };
+          break;
+        case 'body':
+          state.httpRequest.assertions.jsonBody.push(
+            {
+              comparison: action.payload.comparisonType,
+              property: action.payload.property,
+              target: action.payload.target,
+            },
+          );
+          break;
+        case 'headers':
+          state.httpRequest.assertions[action.payload.name].push(
+            {
+              comparison: action.payload.comparisonType,
+              property: action.payload.property,
+              target: action.payload.target,
+            },
+          );
+          break;
+        default:
+          console.log('Assertion type not found');
+      }
+    },
     addLocation: (state, action) => {
       state.locations.push(action.payload);
     },
@@ -37,7 +69,7 @@ export const newtestSlice = createSlice({
 });
 
 export const {
-  addTitle, addMethod, addLocation, addUrl,
+  addTitle, addMethod, addLocation, addUrl, addAssertion,
 } = newtestSlice.actions;
 
 export default newtestSlice.reducer;

--- a/src/features/newtest/newtest.js
+++ b/src/features/newtest/newtest.js
@@ -65,7 +65,7 @@ export const newtestSlice = createSlice({
     toggleLocation: (state, action) => {
       const location = action.payload;
       if (state.locations.includes(location)) {
-        state.locations.filter((l) => l !== location);
+        state.locations = state.locations.filter((l) => l !== location);
       } else {
         state.locations.push(location);
       }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -41,3 +41,8 @@ export const allKeysToCamelCase = (data) => {
     }
   }
 };
+
+export const camelCaseToDisplayName = (str) => {
+  const newStr = str.replace(/[A-Z]/g, (letter) => ` ${letter.toLowerCase()}`);
+  return newStr[0].toUpperCase() + newStr.slice(1);
+};

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -19,13 +19,22 @@ export const formatDateLong = (dueDateStr) => {
   return new Date(Date.parse(dueDateStr, 'YYYY-MM-DD')).toLocaleDateString('en-us', options);
 };
 
+const camelCaseRegex = /^([a-z_]+)$/;
+
+const isCamelCase = (value) => {
+  return (typeof value === 'string' && camelCaseRegex.test(value));
+};
+
 export const allKeysToCamelCase = (data) => {
   const keys = Object.keys(data);
   for (let i = 0; i < keys.length; i += 1) {
     if (typeof data[keys[i]] === 'object' && data[[keys[i]]] !== null) {
       allKeysToCamelCase(data[keys[i]]);
     } else {
-      const tmp = data[keys[i]];
+      let tmp = data[keys[i]];
+      if (isCamelCase(tmp)) {
+        tmp = snakeToCamel(tmp);
+      }
       const newKey = snakeToCamel(keys[i]);
       delete data[keys[i]];
       data[newKey] = tmp;


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR adds functionality to the most basic set of inputs for creating a new test. 

There are two important changes implied by this PR: 
1) comparisonTypes will be formatted in camelCase rather than snake_case (as `tests-crud` and `test-runner` currently expect). As a result, this form can't be used until the necessary changes have been made to `tests-crud` and `test-runner`
2) the assertions property is now an array. I'd originally written this PR to accommodate the existing shape of assertions (`assertions: { headers: [], jsonBody:[], statusCode:{}, responseTime:{} }`) but it required ~100 lines of code (vs. 1 now). This change will also make assertion validation on the backend easier.

Missing: 
* Input for request headers
* Input for request body

Known bugs
* Input clearing

Follow ups
* Migrate `tests-crud` and the rest of the pipeline to expect `camelCase` comparison types and an array of assertions

# Validation 
These inputs values: 
<img width="1025" alt="Screen Shot 2022-07-25 at 12 35 22 PM" src="https://user-images.githubusercontent.com/30358327/180860787-d4180fa1-9ee2-41c4-a6c4-a26bea1a517c.png">

...result in the following payload on "Save":
```
{
    "title": "New UI test",
    "locations": [
        "us-east-1",
        "us-west-1",
        "ca-central-1",
        "eu-north-1"
    ],
    "minutesBetweenRuns": "1",
    "type": "API",
    "httpRequest": {
        "method": "GET",
        "url": "https://trellific.corkboard.dev/api/boards",
        "headers": {},
        "body": {},
        "assertions": [
            {
                "id": "c90ff75f-c971-40c7-9e34-5e5ae109e877",
                "type": "responseTime",
                "property": "",
                "comparison": "lessThan",
                "target": "500"
            },
            {
                "id": "33cabdf6-97d7-41b6-bc1c-37e701162405",
                "type": "statusCode",
                "property": "",
                "comparison": "equalTo",
                "target": "200"
            }
        ]
    }
}
```