### PR TITLE
add parsed json to test config body

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,3 @@
 {
-  "testsCrudUrl": "http://localhost:5001"
+  "testsCrudUrl": "http://testscrud-env.eba-fpb5kcf8.us-east-1.elasticbeanstalk.com"
  }

--- a/src/features/newtest/newtest.js
+++ b/src/features/newtest/newtest.js
@@ -29,7 +29,7 @@ export const newtestSlice = createSlice({
       state.httpRequest.url = action.payload;
     },
     addRequestBody: (state, action) => {
-      state.httpRequest.body = action.payload;
+      state.httpRequest.body = JSON.parse(action.payload);
     },
     addAssertion: (state, action) => {
       state.httpRequest.assertions.push(action.payload);


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR:
* Fixes a bug for POST-based tests by parsing the test form text passed to the `httpRequest.body` config property
* Adds the correct url for the `tests-crud` app

# Validation
Hastily configured a POST-based test, `0726-t3` , in the UI to create new boards `0726-t3 test boar` (sad typo :( ) at `https://www.trellific.corkboard.dev/api/boards`. 

And then verified that the boards were created: 

<img width="469" alt="Screen Shot 2022-07-26 at 7 42 51 PM" src="https://user-images.githubusercontent.com/30358327/181149243-e330a9fc-76d3-4972-be3d-1a334902228a.png">

