### PR TITLE
include last character from textarea in test body

### DIFF
--- a/src/components/test-new/CodeInput.jsx
+++ b/src/components/test-new/CodeInput.jsx
@@ -1,5 +1,5 @@
 import { React, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { addRequestBody } from '../../features/newtest/newtest';
 
 const SPACES_FOR_TAB = 2;
@@ -12,6 +12,7 @@ const SAMPLE_JSON = `{
 
 function CodeInput() {
   const dispatch = useDispatch();
+  const newTestConfiguration = useSelector((state) => state.newtest);
 
   const [requestBody, setRequestBody] = useState({ value: SAMPLE_JSON, caret: -1, target: null });
 
@@ -37,7 +38,7 @@ function CodeInput() {
 
   const handleRequestBodyChange = (e) => {
     setRequestBody({ value: e.target.value, caret: -1, target: e.target });
-    dispatch(addRequestBody(requestBody.value));
+    dispatch(addRequestBody(e.target.value));
   };
 
   return (

--- a/src/components/test-new/CodeInput.jsx
+++ b/src/components/test-new/CodeInput.jsx
@@ -1,5 +1,5 @@
 import { React, useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { addRequestBody } from '../../features/newtest/newtest';
 
 const SPACES_FOR_TAB = 2;
@@ -12,7 +12,6 @@ const SAMPLE_JSON = `{
 
 function CodeInput() {
   const dispatch = useDispatch();
-  const newTestConfiguration = useSelector((state) => state.newtest);
 
   const [requestBody, setRequestBody] = useState({ value: SAMPLE_JSON, caret: -1, target: null });
 


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR:
* Fixes the bug where the last keystroke in the JSON body textarea isn't sent to the test config

# Validation
Configured a POST-based test, `0727-t4` , in the UI to create new boards at https://www.trellific.corkboard.dev/api/boards.

And then verified that the boards were created:

<img width="643" alt="Screen Shot 2022-07-27 at 11 30 07 AM" src="https://user-images.githubusercontent.com/30358327/181346307-ef403f7d-a891-4d9b-97b5-d2140d71c587.png">

