### PR TITLE
sort tests and test runs on /tests view

### DIFF
--- a/src/components/tests/Tests.jsx
+++ b/src/components/tests/Tests.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import apiClient from '../../services/ApiClient';
 import Button from '../shared/Button';
 import TestRows from './TestRows';
+import { sortTestsAndTestRuns } from '../../utils/helpers';
 
 function Tests() {
   const [tests, setTests] = useState([]);
@@ -11,7 +12,7 @@ function Tests() {
     const run = async () => {
       try {
         const testsData = await apiClient.getTests();
-        setTests(testsData.tests);
+        setTests(sortTestsAndTestRuns(testsData.tests));
       } catch (err) {
         console.log(err);
       }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -46,3 +46,12 @@ export const camelCaseToDisplayName = (str) => {
   const newStr = str.replace(/[A-Z]/g, (letter) => ` ${letter.toLowerCase()}`);
   return newStr[0].toUpperCase() + newStr.slice(1);
 };
+
+export const sortTestsAndTestRuns = (tests) => {
+  const testsCopy = JSON.parse(JSON.stringify(tests));
+  testsCopy.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  testsCopy.forEach((test) => {
+    test.runs.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  });
+  return testsCopy;
+};


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Scott Graham <scttgrhm7+public@gmail.com>

this PR sorts the data returned from GET /api/tests in the following ways

- tests are sorted on `createdAt` from newest to oldest
- test runs for each test are sorted on `createdAt` from newest to oldest