### PR TITLE
[!!!DO NOT MERGE!!!] enable this branch of the ui to be included in the express deployment

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,0 @@
-{
-  "testsCrudUrl": "http://testscrud-env.eba-fpb5kcf8.us-east-1.elasticbeanstalk.com"
- }

--- a/src/services/ApiClient.js
+++ b/src/services/ApiClient.js
@@ -1,12 +1,8 @@
 /* eslint-disable consistent-return */
 import axios from 'axios';
-import getTestRunsResponse from '../fixtures/getTestRuns';
 import getTestsResponse from '../fixtures/getTests';
-import getTestRunResponse from '../fixtures/getTestRun';
 
-const config = require('../config.json');
-
-const URL = config.testsCrudUrl;
+const baseUrl = '/api';
 
 function logError(errorResponse) {
   const { response } = errorResponse;
@@ -21,7 +17,7 @@ function logError(errorResponse) {
 const apiClient = {
   createTest: async (test) => {
     try {
-      const { data } = await axios.post(`${URL}/api/tests`, test);
+      const { data } = await axios.post(`${baseUrl}/tests`, test);
       return data;
     } catch (e) {
       logError(e);
@@ -29,7 +25,7 @@ const apiClient = {
   },
   getTests: async () => {
     try {
-      const { data } = await axios.get(`${URL}/api/tests`);
+      const { data } = await axios.get(`${baseUrl}/tests`);
       return data;
     } catch (e) {
       logError(e);
@@ -38,7 +34,7 @@ const apiClient = {
   getTestsTemp: async () => getTestsResponse,
   getTest: async (id) => {
     try {
-      const { data } = await axios.get(`${URL}/api/tests/${id}`);
+      const { data } = await axios.get(`${baseUrl}/tests/${id}`);
       return data;
     } catch (e) {
       logError(e);
@@ -46,7 +42,7 @@ const apiClient = {
   },
   getSideload: async () => {
     try {
-      const { data } = await axios.get(`${URL}/api/sideload`);
+      const { data } = await axios.get(`${baseUrl}/sideload`);
       return data;
     } catch (e) {
       logError(e);
@@ -54,7 +50,7 @@ const apiClient = {
   },
   runTestNow: async () => {
     try {
-      const { data } = await axios.get(`${URL}/api/test/run`);
+      const { data } = await axios.get(`${baseUrl}/test/run`);
       return data;
     } catch (e) {
       logError(e);
@@ -62,7 +58,7 @@ const apiClient = {
   },
   getTestRuns: async ({ testId }) => {
     try {
-      const { data } = await axios.get(`${URL}/api/tests/${testId}/runs`);
+      const { data } = await axios.get(`${baseUrl}/tests/${testId}/runs`);
       return data;
     } catch (e) {
       logError(e);
@@ -70,7 +66,7 @@ const apiClient = {
   },
   getTestRun: async ({ testId, runId }) => {
     try {
-      const { data } = await axios.get(`${URL}/api/tests/${testId}/runs/${runId}`);
+      const { data } = await axios.get(`${baseUrl}/tests/${testId}/runs/${runId}`);
       return data;
     } catch (e) {
       logError(e);


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This is a sister branch of https://github.com/No-Name-temporary/tests-crud/pull/51.

This branch of `tests-ui` is what's pulled into the `tests-crud` branch above. This was done by running `npm run build:ui` from the `tests-crud` root dir (`tests-crud` and `tests-ui` need to be in the same parent directory for this command to work). 

Together, these two branches are deployed in a [new elastic beanstalk environment called `tests-all`](http://testsall-env.eba-mbm2j5vn.us-east-1.elasticbeanstalk.com/tests). This is only for experimental purposes.

# Validation
<img width="1157" alt="Screen Shot 2022-07-28 at 7 47 52 PM" src="https://user-images.githubusercontent.com/30358327/181672390-33b27b23-a19b-410f-a148-854c50ed626b.png">

 