### PR TITLE
attach click handler to delete and run now buttons

### DIFF
--- a/src/components/shared/TestBanner.jsx
+++ b/src/components/shared/TestBanner.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import apiClient from '../../services/ApiClient';
 import { formatDateLong } from '../../utils/helpers';
 import Button from './Button';
 
@@ -20,6 +21,10 @@ function TestBanner({
     return '';
   };
 
+  const handleRunNowClick = (testId) => {
+    apiClient.runTestNow(testId);
+  };
+
   return (
     <div className="mb-6">
       <div className="flex justify-between items-center">
@@ -36,7 +41,7 @@ function TestBanner({
             <Button message="Edit" />
           </div>
           <div className="ml-2">
-            <Button message="Run now" />
+            <Button onClick={() => handleRunNowClick(testData.id)} message="Run now" />
           </div>
         </div>
       </div>

--- a/src/components/tests/TestRow.jsx
+++ b/src/components/tests/TestRow.jsx
@@ -3,8 +3,22 @@ import { Link } from 'react-router-dom';
 import {
   GARBAGE_CAN, GREEN_CHECK_MARK, LIGHTNING, PENCIL, RED_X,
 } from '../../constants/IconUrls';
+import apiClient from '../../services/ApiClient';
 
 function TestRow({ test }) {
+  const reloadPage = () => {
+    window.location.reload();
+  };
+
+  const handleDeleteTest = async (testId) => {
+    await apiClient.deleteTest(testId);
+    reloadPage();
+  };
+
+  const handleRunTest = async (testId) => {
+    await apiClient.runTestNow(testId);
+  };
+
   return (
     <tr>
       <Link to={`/tests/${test.id}`}>
@@ -32,13 +46,14 @@ function TestRow({ test }) {
         mins
       </td>
       <td>
-        <button type="button" className="pl-2">
+        <button onClick={() => handleDeleteTest(test.id)} type="button" className="pl-2">
           <img
             className="h-6 w-auto"
             src={GARBAGE_CAN}
             alt="delete"
           />
         </button>
+
       </td>
       <td>
         <button type="button" className="pl-2">
@@ -50,7 +65,7 @@ function TestRow({ test }) {
         </button>
       </td>
       <td>
-        <button type="button" className="pl-2">
+        <button onClick={() => handleRunTest(test.id)} type="button" className="pl-2">
           <img
             className="h-6 w-auto"
             src={LIGHTNING}

--- a/src/services/ApiClient.js
+++ b/src/services/ApiClient.js
@@ -40,6 +40,14 @@ const apiClient = {
       logError(e);
     }
   },
+  deleteTest: async (id) => {
+    try {
+      const { data } = await axios.delete(`${URL}/api/tests/${id}`);
+      return data;
+    } catch (e) {
+      logError(e);
+    }
+  },
   getSideload: async () => {
     try {
       const { data } = await axios.get(`${URL}/api/sideload`);
@@ -48,9 +56,9 @@ const apiClient = {
       logError(e);
     }
   },
-  runTestNow: async () => {
+  runTestNow: async (testId) => {
     try {
-      const { data } = await axios.get(`${URL}/api/test/run`);
+      const { data } = await axios.post(`${URL}/api/tests/${testId}/run`);
       return data;
     } catch (e) {
       logError(e);


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR attaches event handlers to the delete and run now buttons

# Validation 
* Clicked the delete button, which successfully removed the test from the database (i.e. was no longer displayed in the ui) 
* Clicked the run now button, which successfully sent a request to the appropriate endpoint

# Potential `tests-crud` issues
* Clicking the run now button did not result in run data showing up in the UI, even after waiting for several minutes. This may be a `tests-crud` issue and should be investigated
* Clicking the delete button did remove the test from the DB, but the deleted test remained enabled in EventBridge. This may be a `tests-crud` issue and should be investigated