### PR TITLE
fix minutes display and shorten display for full json values

### DIFF
--- a/src/components/test-run/AssertionRow.jsx
+++ b/src/components/test-run/AssertionRow.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   GREEN_CHECK_MARK, RED_X,
 } from '../../constants/IconUrls';
-import { camelCaseToDisplayName } from '../../utils/helpers';
+import { camelCaseToDisplayName, shortenString } from '../../utils/helpers';
 
 function AssertionRow({ assertion }) {
   return (
@@ -29,7 +29,7 @@ function AssertionRow({ assertion }) {
         {assertion.type === 'responseTime' ? 'ms' : ''}
       </td>
       <td className="whitespace-nowrap py-4 px-3 text-sm text-table-value">
-        {assertion.actualValue}
+        {shortenString(String(assertion.actualValue), 40)}
         {' '}
         {assertion.type === 'responseTime' ? 'ms' : ''}
       </td>

--- a/src/components/tests/TestRow.jsx
+++ b/src/components/tests/TestRow.jsx
@@ -46,7 +46,7 @@ function TestRow({ test }) {
       <td className="whitespace-nowrap py-4 px-3 text-sm text-table-value">
         {test.minutesBetweenRuns}
         {' '}
-        mins
+        {test.minutesBetweenRuns === 1 ? 'min' : 'mins'}
       </td>
       <td>
         <div className="grid align-items-end justify-items-end mr-4">

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -85,3 +85,11 @@ export const flagUrls = (runs) => {
   }
   return urls;
 };
+
+export const shortenString = (string, maxLength) => {
+  let shortened = string;
+  if (string.length > maxLength) {
+    shortened = `${shortened.slice(0, maxLength)}...`;
+  }
+  return shortened;
+};


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR: 
* removes the "s" from "mins" in the test view when the number of minutes is 1
* cuts off and adds ellipsis to long JSON actual values in the test run view

# Validation
<img width="1059" alt="Screen Shot 2022-08-10 at 10 26 30 PM" src="https://user-images.githubusercontent.com/30358327/184069536-31683424-719c-44d6-80e7-6febaf000458.png">


<img width="1030" alt="Screen Shot 2022-08-10 at 10 26 21 PM" src="https://user-images.githubusercontent.com/30358327/184069521-8112b148-9f19-4142-8274-416b117822e9.png">

 