### PR TITLE
parse request body before adding to test config

### DIFF
--- a/src/components/test-edit/TestEdit.jsx
+++ b/src/components/test-edit/TestEdit.jsx
@@ -59,7 +59,7 @@ function TestEdit() {
       method,
       url,
       headers,
-      body: requestBody.value,
+      body: JSON.parse(requestBody.value),
       assertions,
     },
     alertChannels,

--- a/src/components/test-new/TestNew.jsx
+++ b/src/components/test-new/TestNew.jsx
@@ -32,7 +32,7 @@ function TestNew() {
       method,
       url,
       headers,
-      body: requestBody.value,
+      body: JSON.parse(requestBody.value),
       assertions,
     },
     alertChannels,


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR adds parsing to the request body before including it in the test configuration.

# Validation
Created a new test `Create-test-6` which makes a POST request. Requests made it through the loop:
 
<img width="965" alt="Screen Shot 2022-08-15 at 1 32 25 PM" src="https://user-images.githubusercontent.com/30358327/184713319-aacd57e4-13a0-443d-b211-b362f678efbd.png">

