### PR TITLE
remove trailing comma from sample json

### DIFF
--- a/src/components/test-edit/TestEdit.jsx
+++ b/src/components/test-edit/TestEdit.jsx
@@ -59,7 +59,7 @@ function TestEdit() {
       method,
       url,
       headers,
-      body: JSON.parse(requestBody.value),
+      body: JSON.parse(requestBody.value || '{}'),
       assertions,
     },
     alertChannels,

--- a/src/components/test-new/TestNew.jsx
+++ b/src/components/test-new/TestNew.jsx
@@ -3,20 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import apiClient from '../../services/ApiClient';
 import TestForm from './TestForm';
 
-const SAMPLE_JSON = `{
-  "key1": "value1",
-  "key2": "value2",
-  "key3": "value3",
-}
-`;
-
 function TestNew() {
   const navigate = useNavigate();
 
   const [title, setTitle] = useState('');
   const [method, setMethod] = useState('get');
   const [url, setUrl] = useState('');
-  const [requestBody, setRequestBody] = useState({ value: SAMPLE_JSON, caret: -1, target: null });
+  const [requestBody, setRequestBody] = useState({ value: '', caret: -1, target: null });
   const [headers, setHeaders] = useState({});
   const [assertions, setAssertions] = useState([]);
   const [regions, setRegions] = useState([]);
@@ -32,14 +25,15 @@ function TestNew() {
       method,
       url,
       headers,
-      body: JSON.parse(requestBody.value),
+      body: JSON.parse(requestBody.value || '{}'),
       assertions,
     },
     alertChannels,
   });
 
   const handleSaveTest = () => {
-    apiClient.createTest({ test: createTestConfiguration() });
+    const testConfiguration = createTestConfiguration();
+    apiClient.createTest({ test: testConfiguration });
     navigate('/tests');
   };
 

--- a/src/components/test-new/text-block-input/CodeInput.jsx
+++ b/src/components/test-new/text-block-input/CodeInput.jsx
@@ -2,6 +2,13 @@ import { React, useEffect } from 'react';
 
 const SPACES_FOR_TAB = 2;
 
+const SAMPLE_JSON = `{
+  "key1": "value1",
+  "key2": "value2",
+  "key3": "value3"
+}
+`;
+
 function CodeInput({ requestBody, setRequestBody }) {
   useEffect(() => {
     if (requestBody.caret >= 0) {
@@ -35,6 +42,7 @@ function CodeInput({ requestBody, setRequestBody }) {
         onKeyDown={handleTab}
         onChange={handleRequestBodyChange}
         value={requestBody.value}
+        placeholder={SAMPLE_JSON}
       />
     </div>
   );


### PR DESCRIPTION
Co-authored-by: Katarina Rosiak <katarinarosiak@gmail.com>
Co-authored-by: Miles Abbason <miles.abbason@gmail.com>
Co-authored-by: Tim Dronkers <tdronkers@gmail.com>

This PR both removes the trailing comma from the sample JSON and removes that JSON as an initial request body value. It is instead used as a placeholder.

# Validation 
Created a test making a GET request:

<img width="948" alt="Screen Shot 2022-08-15 at 2 43 10 PM" src="https://user-images.githubusercontent.com/30358327/184723677-43bcfc28-0177-47b6-924d-4e55584fe5f4.png">


<img width="945" alt="Screen Shot 2022-08-15 at 2 43 24 PM" src="https://user-images.githubusercontent.com/30358327/184723626-12eaa10b-02c7-4867-8c01-f8f1531251b4.png">

